### PR TITLE
Expose findConfigIn

### DIFF
--- a/src/Floskell.hs
+++ b/src/Floskell.hs
@@ -8,6 +8,7 @@ module Floskell
       Config(..)
     , defaultConfig
     , findConfig
+    , findConfigIn
     , readConfig
     , setStyle
     , setLanguage


### PR DESCRIPTION
Before this change, `floskell` could find config file only from the current directory and up.

However, when used as a library, current directory is not necessarily a directory where the config file is located.

For example, in a multi-project environment, `floskell.json` can be located in a specific project directory while the current directory will be one level up.

The same applies when projects are included as git submodules.

This change allows `floskell` to find a config file that is closest to the file that is being handled. With this method external tools (such as HIE) would be able to provide `floskell` with a starting point when searching for the config.