### PR TITLE
Allow user to specify how exactly to break down import groups

### DIFF
--- a/src/Floskell/Pretty.hs
+++ b/src/Floskell/Pretty.hs
@@ -482,11 +482,15 @@ prefixMatches _ _ = False
 
 
 groupByRules :: [[String]] -> [ImportDecl NodeInfo] -> [[ImportDecl NodeInfo]]
-groupByRules (thisGrp:moreGrps) imports =
-    let (this, more) = partition (\i -> any (\r -> prefixMatches r (moduleName $ importModule i)) thisGrp) imports
-     in this : groupByRules moreGrps more
-groupByRules [] x = [x]
-
+groupByRules g = (\(x, y) -> x ++ [y]) . go g
+    where
+        go :: [[String]] -> [ImportDecl  NodeInfo] -> ([[ImportDecl NodeInfo]], [ImportDecl NodeInfo])
+        go ([]:more) is = let (d, c) = go more is in (c : d, [])
+        go (thisGrp:moreGrps) is =
+            let (this, more) = partition (\i -> any (\r -> prefixMatches r (moduleName $ importModule i)) thisGrp) is
+                (result, rest) = go moreGrps more
+             in (this : result, rest)
+        go [] x = ([], x)
 
 
 prettyImports :: [ImportDecl NodeInfo] -> Printer ()

--- a/src/Floskell/Styles.hs
+++ b/src/Floskell/Styles.hs
@@ -79,7 +79,7 @@ chrisDoneCfg = safeConfig $
 
     cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
                               , cfgOptionSplitLanguagePragmas  = False
-                              , cfgOptionSortImports           = False
+                              , cfgOptionSortImports           = NoImportSort
                               , cfgOptionSortImportLists       = False
                               , cfgOptionAlignSumTypeDecl      = True
                               , cfgOptionPreserveVerticalSpace = False
@@ -187,7 +187,7 @@ cramerCfg = safeConfig $
 
     cfgOptions = OptionConfig { cfgOptionSortPragmas           = True
                               , cfgOptionSplitLanguagePragmas  = True
-                              , cfgOptionSortImports           = True
+                              , cfgOptionSortImports           = SortImportsByPrefix
                               , cfgOptionSortImportLists       = True
                               , cfgOptionAlignSumTypeDecl      = False
                               , cfgOptionPreserveVerticalSpace = True
@@ -272,7 +272,7 @@ gibianskyCfg = safeConfig $
 
     cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
                               , cfgOptionSplitLanguagePragmas  = False
-                              , cfgOptionSortImports           = False
+                              , cfgOptionSortImports           = NoImportSort
                               , cfgOptionSortImportLists       = False
                               , cfgOptionAlignSumTypeDecl      = False
                               , cfgOptionPreserveVerticalSpace = False
@@ -356,7 +356,7 @@ johanTibellCfg = safeConfig $
 
     cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
                               , cfgOptionSplitLanguagePragmas  = False
-                              , cfgOptionSortImports           = False
+                              , cfgOptionSortImports           = NoImportSort
                               , cfgOptionSortImportLists       = False
                               , cfgOptionAlignSumTypeDecl      = True
                               , cfgOptionPreserveVerticalSpace = False


### PR DESCRIPTION
Ability to sort and group imports is important, but in some cases it might be desirable to be able to specify what goes in what groups. This MR allows users to do exactly that.

Rules are a following

- things are sorted alphabetically
- import group consists of one or more module prefixes, everything that matches a module prefix gets placed in corresponding group
- module prefix matches module name and it's submodules: `Foo` matches `Foo` and `Foo.Bar`, but not `FooBar`.
- empty groups are dropped
- any unclaimed modules are placed in the last group

given

```haskell
module Foo where


import Data.Maybe
import GHC.STRef
import Prelude
import Control.Monad.Trans.Maybe
import Control.Arrow
import Control.Applicative
import GHC.IO
import Control.Monad
import GHC.Arr
import System.Mem.Weak
import Data.Bifunctor
import Text.Show
import Control.Applicative.Backwards
import Data.Aeson
import Data.Aeson.TH

import System.IO
import Unsafe.Coerce
import Data.Either
```

and 
```json
      "sort-imports": [["Data.Aeson"], ["Control", "Data"], ["Bar"], ["GHC"]],
```

it produces

```haskell
module Foo where

import           Data.Aeson
import           Data.Aeson.TH

import           Control.Applicative
import           Control.Applicative.Backwards
import           Control.Arrow
import           Control.Monad
import           Control.Monad.Trans.Maybe
import           Data.Bifunctor
import           Data.Either
import           Data.Maybe

import           GHC.Arr
import           GHC.IO
import           GHC.STRef

import           Prelude
import           System.IO
import           System.Mem.Weak
import           Text.Show
import           Unsafe.Coerce
```