### PR TITLE
add config option for blank lines in declarations

### DIFF
--- a/src/Floskell/Config.hs
+++ b/src/Floskell/Config.hs
@@ -213,24 +213,26 @@ data SortImportsRule =
     NoImportSort | SortImportsByPrefix | SortImportsByGroups ![ImportsGroup]
 
 data OptionConfig =
-    OptionConfig { cfgOptionSortPragmas           :: !Bool
-                 , cfgOptionSplitLanguagePragmas  :: !Bool
-                 , cfgOptionSortImports           :: !SortImportsRule
-                 , cfgOptionSortImportLists       :: !Bool
-                 , cfgOptionAlignSumTypeDecl      :: !Bool
-                 , cfgOptionFlexibleOneline       :: !Bool
-                 , cfgOptionPreserveVerticalSpace :: !Bool
+    OptionConfig { cfgOptionSortPragmas             :: !Bool
+                 , cfgOptionSplitLanguagePragmas    :: !Bool
+                 , cfgOptionSortImports             :: !SortImportsRule
+                 , cfgOptionSortImportLists         :: !Bool
+                 , cfgOptionAlignSumTypeDecl        :: !Bool
+                 , cfgOptionFlexibleOneline         :: !Bool
+                 , cfgOptionPreserveVerticalSpace   :: !Bool
+                 , cfgOptionWhereBindingsBlankLines :: !Bool
                  }
     deriving ( Generic )
 
 instance Default OptionConfig where
-    def = OptionConfig { cfgOptionSortPragmas           = False
-                       , cfgOptionSplitLanguagePragmas  = False
-                       , cfgOptionSortImports           = NoImportSort
-                       , cfgOptionSortImportLists       = False
-                       , cfgOptionAlignSumTypeDecl      = False
-                       , cfgOptionFlexibleOneline       = False
-                       , cfgOptionPreserveVerticalSpace = False
+    def = OptionConfig { cfgOptionSortPragmas             = False
+                       , cfgOptionSplitLanguagePragmas    = False
+                       , cfgOptionSortImports             = NoImportSort
+                       , cfgOptionSortImportLists         = False
+                       , cfgOptionAlignSumTypeDecl        = False
+                       , cfgOptionFlexibleOneline         = False
+                       , cfgOptionPreserveVerticalSpace   = False
+                       , cfgOptionWhereBindingsBlankLines = True
                        }
 
 data Config = Config { cfgPenalty :: !PenaltyConfig

--- a/src/Floskell/Styles.hs
+++ b/src/Floskell/Styles.hs
@@ -4,6 +4,7 @@
 module Floskell.Styles ( Style(..), styles ) where
 
 import qualified Data.Map        as Map
+import qualified Data.Set        as Set
 import           Data.Text       ( Text )
 
 import           Floskell.Config
@@ -78,14 +79,14 @@ chrisDoneCfg = safeConfig $
 
     groupWsOverrides = []
 
-    cfgOptions = OptionConfig { cfgOptionSortPragmas             = False
-                              , cfgOptionSplitLanguagePragmas    = False
-                              , cfgOptionSortImports             = NoImportSort
-                              , cfgOptionSortImportLists         = False
-                              , cfgOptionAlignSumTypeDecl        = True
-                              , cfgOptionFlexibleOneline         = False
-                              , cfgOptionPreserveVerticalSpace   = False
-                              , cfgOptionWhereBindingsBlankLines = True
+    cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
+                              , cfgOptionSplitLanguagePragmas  = False
+                              , cfgOptionSortImports           = NoImportSort
+                              , cfgOptionSortImportLists       = False
+                              , cfgOptionAlignSumTypeDecl      = True
+                              , cfgOptionFlexibleOneline       = False
+                              , cfgOptionPreserveVerticalSpace = False
+                              , cfgOptionDeclNoBlankLines      = Set.empty
                               }
 
 cramerCfg :: Config
@@ -190,14 +191,14 @@ cramerCfg = safeConfig $
         ]
 
     cfgOptions =
-        OptionConfig { cfgOptionSortPragmas             = True
-                     , cfgOptionSplitLanguagePragmas    = True
-                     , cfgOptionSortImports             = SortImportsByPrefix
-                     , cfgOptionSortImportLists         = True
-                     , cfgOptionAlignSumTypeDecl        = False
-                     , cfgOptionFlexibleOneline         = False
-                     , cfgOptionPreserveVerticalSpace   = True
-                     , cfgOptionWhereBindingsBlankLines = True
+        OptionConfig { cfgOptionSortPragmas           = True
+                     , cfgOptionSplitLanguagePragmas  = True
+                     , cfgOptionSortImports           = SortImportsByPrefix
+                     , cfgOptionSortImportLists       = True
+                     , cfgOptionAlignSumTypeDecl      = False
+                     , cfgOptionFlexibleOneline       = False
+                     , cfgOptionPreserveVerticalSpace = True
+                     , cfgOptionDeclNoBlankLines      = Set.empty
                      }
 
 gibianskyCfg :: Config
@@ -278,14 +279,14 @@ gibianskyCfg = safeConfig $
     groupWsOverrides =
         [ (ConfigMapKey (Just "{") Nothing, Whitespace WsBoth WsAfter False) ]
 
-    cfgOptions = OptionConfig { cfgOptionSortPragmas             = False
-                              , cfgOptionSplitLanguagePragmas    = False
-                              , cfgOptionSortImports             = NoImportSort
-                              , cfgOptionSortImportLists         = False
-                              , cfgOptionAlignSumTypeDecl        = False
-                              , cfgOptionFlexibleOneline         = False
-                              , cfgOptionPreserveVerticalSpace   = False
-                              , cfgOptionWhereBindingsBlankLines = True
+    cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
+                              , cfgOptionSplitLanguagePragmas  = False
+                              , cfgOptionSortImports           = NoImportSort
+                              , cfgOptionSortImportLists       = False
+                              , cfgOptionAlignSumTypeDecl      = False
+                              , cfgOptionFlexibleOneline       = False
+                              , cfgOptionPreserveVerticalSpace = False
+                              , cfgOptionDeclNoBlankLines      = Set.empty
                               }
 
 johanTibellCfg :: Config
@@ -365,14 +366,14 @@ johanTibellCfg = safeConfig $
           )
         ]
 
-    cfgOptions = OptionConfig { cfgOptionSortPragmas             = False
-                              , cfgOptionSplitLanguagePragmas    = False
-                              , cfgOptionSortImports             = NoImportSort
-                              , cfgOptionSortImportLists         = False
-                              , cfgOptionAlignSumTypeDecl        = True
-                              , cfgOptionFlexibleOneline         = True
-                              , cfgOptionPreserveVerticalSpace   = False
-                              , cfgOptionWhereBindingsBlankLines = True
+    cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
+                              , cfgOptionSplitLanguagePragmas  = False
+                              , cfgOptionSortImports           = NoImportSort
+                              , cfgOptionSortImportLists       = False
+                              , cfgOptionAlignSumTypeDecl      = True
+                              , cfgOptionFlexibleOneline       = True
+                              , cfgOptionPreserveVerticalSpace = False
+                              , cfgOptionDeclNoBlankLines      = Set.empty
                               }
 
 -- | Base style definition.

--- a/src/Floskell/Styles.hs
+++ b/src/Floskell/Styles.hs
@@ -78,13 +78,14 @@ chrisDoneCfg = safeConfig $
 
     groupWsOverrides = []
 
-    cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
-                              , cfgOptionSplitLanguagePragmas  = False
-                              , cfgOptionSortImports           = NoImportSort
-                              , cfgOptionSortImportLists       = False
-                              , cfgOptionAlignSumTypeDecl      = True
-                              , cfgOptionFlexibleOneline       = False
-                              , cfgOptionPreserveVerticalSpace = False
+    cfgOptions = OptionConfig { cfgOptionSortPragmas             = False
+                              , cfgOptionSplitLanguagePragmas    = False
+                              , cfgOptionSortImports             = NoImportSort
+                              , cfgOptionSortImportLists         = False
+                              , cfgOptionAlignSumTypeDecl        = True
+                              , cfgOptionFlexibleOneline         = False
+                              , cfgOptionPreserveVerticalSpace   = False
+                              , cfgOptionWhereBindingsBlankLines = True
                               }
 
 cramerCfg :: Config
@@ -189,13 +190,14 @@ cramerCfg = safeConfig $
         ]
 
     cfgOptions =
-        OptionConfig { cfgOptionSortPragmas           = True
-                     , cfgOptionSplitLanguagePragmas  = True
-                     , cfgOptionSortImports           = SortImportsByPrefix
-                     , cfgOptionSortImportLists       = True
-                     , cfgOptionAlignSumTypeDecl      = False
-                     , cfgOptionFlexibleOneline       = False
-                     , cfgOptionPreserveVerticalSpace = True
+        OptionConfig { cfgOptionSortPragmas             = True
+                     , cfgOptionSplitLanguagePragmas    = True
+                     , cfgOptionSortImports             = SortImportsByPrefix
+                     , cfgOptionSortImportLists         = True
+                     , cfgOptionAlignSumTypeDecl        = False
+                     , cfgOptionFlexibleOneline         = False
+                     , cfgOptionPreserveVerticalSpace   = True
+                     , cfgOptionWhereBindingsBlankLines = True
                      }
 
 gibianskyCfg :: Config
@@ -276,13 +278,14 @@ gibianskyCfg = safeConfig $
     groupWsOverrides =
         [ (ConfigMapKey (Just "{") Nothing, Whitespace WsBoth WsAfter False) ]
 
-    cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
-                              , cfgOptionSplitLanguagePragmas  = False
-                              , cfgOptionSortImports           = NoImportSort
-                              , cfgOptionSortImportLists       = False
-                              , cfgOptionAlignSumTypeDecl      = False
-                              , cfgOptionFlexibleOneline       = False
-                              , cfgOptionPreserveVerticalSpace = False
+    cfgOptions = OptionConfig { cfgOptionSortPragmas             = False
+                              , cfgOptionSplitLanguagePragmas    = False
+                              , cfgOptionSortImports             = NoImportSort
+                              , cfgOptionSortImportLists         = False
+                              , cfgOptionAlignSumTypeDecl        = False
+                              , cfgOptionFlexibleOneline         = False
+                              , cfgOptionPreserveVerticalSpace   = False
+                              , cfgOptionWhereBindingsBlankLines = True
                               }
 
 johanTibellCfg :: Config
@@ -362,13 +365,14 @@ johanTibellCfg = safeConfig $
           )
         ]
 
-    cfgOptions = OptionConfig { cfgOptionSortPragmas           = False
-                              , cfgOptionSplitLanguagePragmas  = False
-                              , cfgOptionSortImports           = NoImportSort
-                              , cfgOptionSortImportLists       = False
-                              , cfgOptionAlignSumTypeDecl      = True
-                              , cfgOptionFlexibleOneline       = True
-                              , cfgOptionPreserveVerticalSpace = False
+    cfgOptions = OptionConfig { cfgOptionSortPragmas             = False
+                              , cfgOptionSplitLanguagePragmas    = False
+                              , cfgOptionSortImports             = NoImportSort
+                              , cfgOptionSortImportLists         = False
+                              , cfgOptionAlignSumTypeDecl        = True
+                              , cfgOptionFlexibleOneline         = True
+                              , cfgOptionPreserveVerticalSpace   = False
+                              , cfgOptionWhereBindingsBlankLines = True
                               }
 
 -- | Base style definition.


### PR DESCRIPTION
A trivial PR to add a config option for blank lines in where bindings (partially addressing #19). The defaults are unchanged.

TODO:
 - add a test?
 - maybe blank lines should be configured more generally?