### PR TITLE
Support for ghc-8.10.1

### DIFF
--- a/floskell.cabal
+++ b/floskell.cabal
@@ -42,7 +42,7 @@ library
                      Floskell.Printers
                      Floskell.Styles
                      Floskell.Types
-  build-depends:     base >=4.9 && <4.14
+  build-depends:     base >=4.9 && <4.15
                    , aeson >=0.11.3.0 && <1.5
                    , attoparsec >=0.13.1.0 && <0.14
                    , bytestring >=0.10.8.1 && <0.11
@@ -62,12 +62,12 @@ executable floskell
   hs-source-dirs:    src/main
   ghc-options:       -Wall -Wno-missing-home-modules -optP-Wno-nonportable-include-path
   main-is:           Main.hs
-  build-depends:     base >=4.9 && <4.14
+  build-depends:     base >=4.9 && <4.15
                    , floskell
                    , aeson-pretty >=0.8.2 && <0.9
                    , bytestring >=0.10.8.1 && <0.11
                    , directory >=1.2.6.2 && <1.4
-                   , ghc-prim >=0.5.0.0 && <0.6
+                   , ghc-prim >=0.5.0.0 && <0.7
                    , haskell-src-exts >= 1.19 && <1.24
                    , optparse-applicative >=0.12.1.0 && <0.16
                    , text >=1.2.2.2 && <1.3
@@ -78,7 +78,7 @@ test-suite floskell-test
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N
   main-is:           Test.hs
   other-modules:     Markdone
-  build-depends:     base >=4.9 && <4.14
+  build-depends:     base >=4.9 && <4.15
                    , floskell
                    , bytestring >=0.10.8.1 && <0.11
                    , deepseq >=1.4.2.0 && <1.5
@@ -94,13 +94,13 @@ benchmark floskell-bench
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N
   main-is:           Benchmark.hs
   other-modules:     Markdone
-  build-depends:     base >=4.9 && <4.14
+  build-depends:     base >=4.9 && <4.15
                    , floskell
                    , bytestring >=0.10.8.1 && <0.11
                    , criterion >=1.1.1.0 && <1.6
                    , deepseq >=1.4.2.0 && <1.5
                    , exceptions >=0.8.3 && <0.11
-                   , ghc-prim >=0.5.0.0 && <0.6
+                   , ghc-prim >=0.5.0.0 && <0.7
                    , haskell-src-exts >= 1.19 && < 1.24
                    , text >=1.2.2.2 && <1.3
                    , utf8-string >=1.0.1.1 && <1.1


### PR DESCRIPTION
* Simply relaxing upper bounds of base and ghc-prim. 
  * It compiles with `cabal build -w ghc-8.10.1` 
  * i've run the test suite in my windows 10 and it fails like master with ghc-8.8.3 so i cant use it as check.
* Needed for haskell-ide-engine and haskell-language-server
* Maybe a hackage revision would be enough to add the support, as there is no code changes
