### PR TITLE
Include styles/*.md in source tarball

### DIFF
--- a/floskell.cabal
+++ b/floskell.cabal
@@ -31,6 +31,7 @@ extra-source-files:
     BENCHMARK.md
     TEST.md
     stack.yaml
+    styles/*.md
 
 source-repository head
     type:     git


### PR DESCRIPTION
The tests are currently failing due to missing these files, when building from a hackage source tarball:

```
Running 1 test suites...
Test suite floskell-test: RUNNING...
floskell-test: styles/base.md: openBinaryFile: does not exist (No such file or directory)
Test suite floskell-test: FAIL
```