### PR TITLE
Allow building with GHC 9.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macOS-latest ]
-        ghc: [ '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8' ]
+        ghc: [ '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10' ]
         include:
           - os: ubuntu-latest
             ghc: '8.4'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,14 @@ jobs:
         exclude:
           - os: macOS-latest
             ghc: '8.4'
+          - os: macOS-latest
+            ghc: '8.6'
+          - os: macOS-latest
+            ghc: '8.8'
+          - os: macOS-latest
+            ghc: '8.10'
+          - os: macOS-latest
+            ghc: '9.0'
 
     runs-on: ${{ matrix.os }}
 

--- a/floskell.cabal
+++ b/floskell.cabal
@@ -56,7 +56,7 @@ library
     default-language: Haskell2010
     ghc-options:      -Wall
     build-depends:
-        base >=4.9 && <4.20,
+        base >=4.9 && <4.21,
         aeson >=0.11.3.0 && <2.3,
         attoparsec >=0.13.1.0 && <0.15,
         attoparsec-aeson >=2.1.0.0 && <2.3,
@@ -80,7 +80,7 @@ executable floskell
         -Wall -Wno-missing-home-modules -optP-Wno-nonportable-include-path
 
     build-depends:
-        base >=4.9 && <4.20,
+        base >=4.9 && <4.21,
         floskell -any,
         aeson-pretty >=0.8.2 && <0.9,
         ansi-wl-pprint >=0.6.6 && <1.1,
@@ -99,7 +99,7 @@ test-suite floskell-test
     default-language: Haskell2010
     ghc-options:      -Wall -threaded -rtsopts -with-rtsopts=-N
     build-depends:
-        base >=4.9 && <4.20,
+        base >=4.9 && <4.21,
         floskell -any,
         bytestring >=0.10.8.1 && <0.13,
         deepseq >=1.4.2.0 && <1.6,
@@ -116,7 +116,7 @@ benchmark floskell-bench
     default-language: Haskell2010
     ghc-options:      -Wall -threaded -rtsopts -with-rtsopts=-N
     build-depends:
-        base >=4.9 && <4.20,
+        base >=4.9 && <4.21,
         floskell -any,
         bytestring >=0.10.8.1 && <0.13,
         criterion >=1.1.1.0 && <1.7,


### PR DESCRIPTION
Hello @ennocramer,
I'm working on [upgrading haskell-language-server](https://github.com/haskell/haskell-language-server/pull/4233) to support ghc 9.10. Part of it is allowing floskell to work with this new version of GHC. Could you please release a new version of floskell to hackage if CI passes? If you want I can include version bumps of cabal file in this PR..

Resolves https://github.com/ennocramer/floskell/issues/81